### PR TITLE
Complete enrollments

### DIFF
--- a/comarch_client/client.py
+++ b/comarch_client/client.py
@@ -342,16 +342,19 @@ class ComarchSOAPAsyncClient:
 
         return await self._make_request("nonAirlineAccrual", args)
 
-    async def enroll(self, customer: Customer, is_complete: bool = False) -> dict:
+    async def enroll(self, customer: Customer, is_complete: bool = False, password: Optional[str] = None) -> dict:
         """
         Method for enrolling a new program member.
 
-        :param customer: new customer data
-        :param is_complete: "False" indicates that it is "quick enrollment" (see Comarch docs)
+        :param customer:    New customer data
+        :param is_complete: False value indicates that it is "quick enrollment" (see Comarch docs)
+        :param password:    Customer password. Required, except for quick enrollment.
 
         :return:
         """
         args = dict(
             customer=customer.to_comarch(),
             incompleteData="N" if is_complete else "Y")
+        if password:
+            args["password"] = password
         return await self._make_request("enroll", args)

--- a/comarch_client/models/__init__.py
+++ b/comarch_client/models/__init__.py
@@ -1,3 +1,4 @@
 from .extended_attributes import ExtendedAttribute  # noqa
 from .communication_preferences import CommunicationPreferences  # noqa
 from .address import Address  # noqa
+from .phone import PhoneData  # noqa

--- a/comarch_client/models/customer.py
+++ b/comarch_client/models/customer.py
@@ -2,24 +2,30 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Optional, List
 
-from comarch_client.models import ExtendedAttribute, CommunicationPreferences, Address
+from comarch_client.models import ExtendedAttribute, CommunicationPreferences, Address, PhoneData
 
 
 @dataclass
 class Customer:
-    """ Customer model
+    """Customer model
 
-    Minimalistic, just enough to enroll (create) a new one via SOAP API.
+    Minimalistic, just enough to enroll (create) an active account via SOAP API.
     """
 
     # Fields have pretty much self-descriptive names so no docstrings here yet.
+    # Phones and title may be omitted for quick enrollment.
+    # But they are still required to make account active.
     login: str
     first_name: str
     last_name: str
     birthdate: date
+    phones: List[PhoneData]
     addresses: List[Address]
     communication_preferences: CommunicationPreferences
     extended_attributes: List[ExtendedAttribute]
+
+    title: Optional[str] = None
+    gender: Optional[str] = None
 
     # loyalty card number belonging to this customer (may be None for enroll - Comarch will assign it)
     card_number: Optional[str] = None
@@ -30,10 +36,15 @@ class Customer:
             firstName=self.first_name,
             lastName=self.last_name,
             dateOfBirth=self.birthdate.strftime("%d%m%Y"),
+            phones=[item.to_comarch() for item in self.phones],
             address=[item.to_comarch() for item in self.addresses],
             commPrefs=self.communication_preferences.to_comarch(),
             extAttributes=[item.to_comarch() for item in self.extended_attributes],
         )
-        if self.card_number:
-            result['cardNumber'] = self.card_number
+        optionals = {
+            "title": self.title,
+            "gender": self.gender,
+            "cardNumber": self.card_number,
+        }
+        result.update({k: v for k, v in optionals.items() if v})
         return result

--- a/comarch_client/models/phone.py
+++ b/comarch_client/models/phone.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class PhoneData:
+    """ Customer phone object """
+
+    phone_number: str
+    phone_type: Optional[str] = None  # from docs:  H – home, B – business, M – mobile
+    alt_phone_number: Optional[str] = None
+    alt_phone_type: Optional[str] = None
+    fax: Optional[str] = None
+
+    def to_comarch(self) -> dict:
+        res = dict(
+            phoneNumber=self.phone_number,
+            phoneType=self.phone_type,
+            altPhoneNumber=self.alt_phone_number,
+            altPhoneType=self.alt_phone_type,
+            fax=self.fax,
+        )
+        return {k: v for k, v in res.items() if v is not None}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requires = [
 
 setup(
     name="comarch_client",
-    version="0.2.3",
+    version="0.3.0",
     description="comarch soap client",
     long_description=open("README.rst").read(),
     author="Utair",


### PR DESCRIPTION
To spend points we need customer account status to be "A" (active).
Quick enrollment creates accounts with "O" (open).

So, this PR adds some parameters neccessary to enroll new members completely.